### PR TITLE
bump actions/checkout version

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,7 +9,7 @@ jobs:
     name: Publish
     runs-on: ubuntu-18.04
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
       - uses: dylanvann/publish-github-action@v1.1.49
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     name: Test
     runs-on: ubuntu-18.04
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
       - name: Install
         run: yarn install --frozen-lockfile
       - name: Build


### PR DESCRIPTION
Signed-off-by: Kevin Neville <kevin@neville.se>

The current versions are generating warnings, and may be the reasons to the warnings in https://github.com/Snowflake-Labs/terraform-provider-snowflake/actions/runs/3361622276 due to https://github.com/Snowflake-Labs/terraform-provider-snowflake/blob/d43fd0010b08eb0372e734096afbe426a98edb82/.github/workflows/ok-to-test.yml#L14.